### PR TITLE
[codex] Handle zero p-values and FDR in hyp_dots

### DIFF
--- a/R/hyp_dots.R
+++ b/R/hyp_dots.R
@@ -75,6 +75,9 @@
     
     df.melted <- reshape2::melt(as.matrix(df))
     colnames(df.melted) <- c("label", "signature", "significance")
+    df.melted$significance <- ifelse(df.melted$significance < .Machine$double.eps,
+                                      .Machine$double.eps,
+                                      df.melted$significance)
     df.melted$size <- 1
     
     if (size_by == "significance") {
@@ -172,6 +175,9 @@
 
     # Plotting variables
     df$significance <- df[,val]
+    df$significance <- ifelse(df$significance < .Machine$double.eps,
+                              .Machine$double.eps,
+                              df$significance)
     df$size <- 1
     
     if (size_by == "significance") {

--- a/tests/testthat/test-hyp_dots.R
+++ b/tests/testthat/test-hyp_dots.R
@@ -61,3 +61,27 @@ test_that("hyp_dots() is working", {
     expect_equal(names(p), c("Signature 1", "Signature 2", "Signature 3"))
     expect_is(p[["Signature 3"]], "gg")
 })
+
+test_that("hyp_dots() thresholds zero p-values and FDR before plotting", {
+
+    hyp_df <- data.frame(
+        label = c("pathway_a", "pathway_b"),
+        pval = c(0, 0.01),
+        fdr = c(0, 0.02),
+        overlap = c(3, 4),
+        geneset = c(10, 20)
+    )
+    hyp_obj <- hyp$new(hyp_df)
+
+    p <- hyp_dots(hyp_obj, val="pval", size_by="significance", top=NULL)
+    expect_true(all(p$data$significance >= .Machine$double.eps))
+    expect_true(all(p$data$size >= .Machine$double.eps))
+
+    p <- hyp_dots(hyp_obj, val="fdr", top=NULL)
+    expect_true(all(p$data$significance >= .Machine$double.eps))
+
+    multihyp_obj <- multihyp$new(list("Signature 1"=hyp_obj, "Signature 2"=hyp_obj))
+    p <- hyp_dots(multihyp_obj, val="pval", size_by="significance", top=NULL, merge=TRUE)
+    expect_true(all(p$data$significance >= .Machine$double.eps))
+    expect_true(all(p$data$size >= .Machine$double.eps))
+})


### PR DESCRIPTION
## Summary
- Threshold plotted hyp_dots significance values below .Machine$double.eps before applying log-based color and size scales.
- Cover both single hyp plots and merged multihyp dot plots when p-values or FDR are zero.

## Why
Zero p-values/FDR can break or distort significance-based dot coloring and sizing because the plotting scales use log transforms.

## Validation
- Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hyp_dots.R")'
- Rscript -e 'devtools::test()'